### PR TITLE
bump guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/guzzle": "^7.3 || ^7.10",
         "guzzlehttp/psr7": "^1.7 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Criteo is using very old guzzle version. This restricts other dependencies. Not to break anything I'm leaving old version as is, but allowing ^7.10 as well. This will unblock newer projects.